### PR TITLE
re-creating removed directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,6 @@ clean:
 .PHONY: static-files
 static-files: client/node_modules
 	@rm -rf public/*
+	@mkdir public
 	@cd client && npm run build
 	@mv client/build/* public/


### PR DESCRIPTION
If not re-creating deleted directory `make static-files` produces following error at the end:
```bash
mv: target 'public/' is not a directory
Makefile:40: recipe for target 'static-files' failed
make: *** [static-files] Error 1
```